### PR TITLE
Joao/no double tap bug

### DIFF
--- a/H19MediaViewer/MediaViewerInteractiveImageView.swift
+++ b/H19MediaViewer/MediaViewerInteractiveImageView.swift
@@ -21,11 +21,16 @@ public class MediaViewerInteractiveImageView: UIView {
         }
     }
 
-    public var imageView: UIImageView!
-    public var scrollView: UIScrollView!
-    public var activityIndicator: UIActivityIndicatorView!
+    public let imageView = UIImageView()
+    public let scrollView = UIScrollView()
+    public let activityIndicator = UIActivityIndicatorView(style: .whiteLarge)
 
-    public var zoomDoubleTapGestureRecogniser: UITapGestureRecognizer!
+    public lazy var zoomDoubleTapGestureRecogniser: UIGestureRecognizer = {
+        let gesture = UITapGestureRecognizer(target: self, action:
+            #selector(MediaViewerInteractiveImageView.viewDoubleTapped(_:)))
+        gesture.numberOfTapsRequired = 2
+        return gesture
+    }()
 
     // MARK: private properties
 
@@ -53,7 +58,7 @@ public class MediaViewerInteractiveImageView: UIView {
 
     // MARK: public - selectors
 
-    @objc public func viewDoubleTapped(_ sender: UITapGestureRecognizer) {
+    @objc func viewDoubleTapped(_ sender: UITapGestureRecognizer) {
         if scrollView.zoomScale <= 1.01 {
             let zoomPoint = sender.location(in: scrollView)
 
@@ -84,7 +89,7 @@ public class MediaViewerInteractiveImageView: UIView {
     }
 
     private func setupImageView() {
-        imageView = UIImageView(frame: scrollView.bounds)
+        imageView.frame = scrollView.bounds
         imageView.contentMode = .scaleAspectFit
         imageView.clipsToBounds = true
         scrollView.addSubview(imageView)
@@ -92,7 +97,7 @@ public class MediaViewerInteractiveImageView: UIView {
     }
 
     private func setupScrollView() {
-        scrollView = UIScrollView(frame: bounds)
+        scrollView.frame = bounds
         scrollView.clipsToBounds = false
         scrollView.isUserInteractionEnabled = true
         scrollView.backgroundColor = UIColor.clear
@@ -106,7 +111,6 @@ public class MediaViewerInteractiveImageView: UIView {
     }
 
     private func setupActivityIndicatorView() {
-        activityIndicator = UIActivityIndicatorView(style: .whiteLarge)
         activityIndicator.isHidden = true
         activityIndicator.translatesAutoresizingMaskIntoConstraints = false
         addSubview(activityIndicator)
@@ -127,10 +131,6 @@ public class MediaViewerInteractiveImageView: UIView {
     }
 
     private func setupTapGestureRecogniser() {
-        zoomDoubleTapGestureRecogniser = UITapGestureRecognizer(target: self,
-                                                                action: #selector(MediaViewerInteractiveImageView.viewDoubleTapped(_:))
-        )
-        zoomDoubleTapGestureRecogniser.numberOfTapsRequired = 2
         addGestureRecognizer(zoomDoubleTapGestureRecogniser)
     }
 

--- a/H19MediaViewer/MediaViewerInteractiveImageView.swift
+++ b/H19MediaViewer/MediaViewerInteractiveImageView.swift
@@ -26,8 +26,7 @@ public class MediaViewerInteractiveImageView: UIView {
     public let activityIndicator = UIActivityIndicatorView(style: .whiteLarge)
 
     public lazy var zoomDoubleTapGestureRecogniser: UIGestureRecognizer = {
-        let gesture = UITapGestureRecognizer(target: self, action:
-            #selector(MediaViewerInteractiveImageView.viewDoubleTapped(_:)))
+        let gesture = UITapGestureRecognizer(target: self, action: #selector(viewDoubleTapped(_:)))
         gesture.numberOfTapsRequired = 2
         return gesture
     }()

--- a/H19MediaViewer/MediaViewerInteractiveImageView.swift
+++ b/H19MediaViewer/MediaViewerInteractiveImageView.swift
@@ -21,16 +21,11 @@ public class MediaViewerInteractiveImageView: UIView {
         }
     }
 
-    public var imageView = UIImageView()
-    public let activityIndicator = UIActivityIndicatorView(style: .whiteLarge)
+    public var imageView: UIImageView!
+    public var scrollView: UIScrollView!
+    public var activityIndicator: UIActivityIndicatorView!
 
-    public lazy var scrollView = { return UIScrollView(frame: bounds) }()
-
-    public var zoomDoubleTapGestureRecogniser: UITapGestureRecognizer = {
-        let gesture = UITapGestureRecognizer(target: self, action: #selector(viewDoubleTapped(_:)))
-        gesture.numberOfTapsRequired = 2
-        return gesture
-    }()
+    public var zoomDoubleTapGestureRecogniser: UITapGestureRecognizer!
 
     // MARK: private properties
 
@@ -89,7 +84,7 @@ public class MediaViewerInteractiveImageView: UIView {
     }
 
     private func setupImageView() {
-        imageView.frame = scrollView.bounds
+        imageView = UIImageView(frame: scrollView.bounds)
         imageView.contentMode = .scaleAspectFit
         imageView.clipsToBounds = true
         scrollView.addSubview(imageView)
@@ -97,6 +92,7 @@ public class MediaViewerInteractiveImageView: UIView {
     }
 
     private func setupScrollView() {
+        scrollView = UIScrollView(frame: bounds)
         scrollView.clipsToBounds = false
         scrollView.isUserInteractionEnabled = true
         scrollView.backgroundColor = UIColor.clear
@@ -110,6 +106,7 @@ public class MediaViewerInteractiveImageView: UIView {
     }
 
     private func setupActivityIndicatorView() {
+        activityIndicator = UIActivityIndicatorView(style: .whiteLarge)
         activityIndicator.isHidden = true
         activityIndicator.translatesAutoresizingMaskIntoConstraints = false
         addSubview(activityIndicator)
@@ -130,6 +127,10 @@ public class MediaViewerInteractiveImageView: UIView {
     }
 
     private func setupTapGestureRecogniser() {
+        zoomDoubleTapGestureRecogniser = UITapGestureRecognizer(target: self,
+                                                                action: #selector(MediaViewerInteractiveImageView.viewDoubleTapped(_:))
+        )
+        zoomDoubleTapGestureRecogniser.numberOfTapsRequired = 2
         addGestureRecognizer(zoomDoubleTapGestureRecogniser)
     }
 


### PR DESCRIPTION
During Swift5 upgrade, while fixing some "forced coercion" warnings, I removed the double tap to zoom functionality. It's now back!