### PR TITLE
[Maintenance] :: Xcode 26 build issues 

### DIFF
--- a/H19MediaViewer/MediaViewerImageAction.swift
+++ b/H19MediaViewer/MediaViewerImageAction.swift
@@ -1,5 +1,4 @@
 import UIKit
-import AssetsLibrary
 import Photos
 
 public enum MediaViewerImageActionType {

--- a/H19MediaViewerTests/MediaViewerImageActionTests.swift
+++ b/H19MediaViewerTests/MediaViewerImageActionTests.swift
@@ -1,7 +1,6 @@
 import XCTest
 @testable import H19MediaViewer
 import Nimble
-import AssetsLibrary
 import Photos
 
 class MockPhotoLibrary: PHPhotoLibrary {

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,41 @@
+{
+  "pins" : [
+    {
+      "identity" : "cwlcatchexception",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/mattgallagher/CwlCatchException.git",
+      "state" : {
+        "revision" : "07b2ba21d361c223e25e3c1e924288742923f08c",
+        "version" : "2.2.1"
+      }
+    },
+    {
+      "identity" : "cwlpreconditiontesting",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/mattgallagher/CwlPreconditionTesting.git",
+      "state" : {
+        "revision" : "0139c665ebb45e6a9fbdb68aabfd7c39f3fe0071",
+        "version" : "2.2.2"
+      }
+    },
+    {
+      "identity" : "nimble",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Quick/Nimble.git",
+      "state" : {
+        "revision" : "7795df4fff1a9cd231fe4867ae54f4dc5f5734f9",
+        "version" : "13.7.1"
+      }
+    },
+    {
+      "identity" : "sdwebimage",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/SDWebImage/SDWebImage.git",
+      "state" : {
+        "revision" : "34cf2423a2c4088d06a3b08655603b5bc3eeeb3a",
+        "version" : "5.21.2"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/SDWebImage/SDWebImage.git", from: "5.0.0"),
-        .package(url:  "https://github.com/Quick/Nimble.git", from: "13.0.0")
+        .package(url: "https://github.com/Quick/Nimble.git", from: "13.0.0")
     ],
     targets: [
         .target(

--- a/Package.swift
+++ b/Package.swift
@@ -13,20 +13,23 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/SDWebImage/SDWebImage.git", from: "5.0.0")
+        .package(url: "https://github.com/SDWebImage/SDWebImage.git", from: "5.0.0"),
+        .package(url:  "https://github.com/Quick/Nimble.git", from: "13.0.0")
     ],
     targets: [
         .target(
             name: "H19MediaViewer",
             dependencies: ["SDWebImage"],
             path: "H19MediaViewer",
-            exclude: ["Tests"],
             resources: []
         ),
         .testTarget(
             name: "H19MediaViewerTests",
-            dependencies: ["H19MediaViewer"],
-            path: "Tests"
+            dependencies: [
+                "H19MediaViewer",
+                "Nimble"
+            ],
+            path: "H19MediaViewerTests"
         )
     ]
 )


### PR DESCRIPTION
Fixed package not building under Xcode 26 due to use of a deprecated import `AssetsLibrary`
Minor tweaks under `Package.swift` to fix missing dependecies under test target and wrong path for test target