### PR TITLE
[Fix] :: Full-screen media viewer not appearing in scene-based apps

### DIFF
--- a/H19MediaViewer/MediaViewer.swift
+++ b/H19MediaViewer/MediaViewer.swift
@@ -108,7 +108,17 @@ public class MediaViewer: UIViewController {
      Use present to show MediaViewer. Do not use presentViewController.
      */
     public func present() {
-        foregroundWindow = UIWindow(frame: UIScreen.main.bounds)
+        // A window must be attached to an active UIWindowScene to render in a
+        // scene-based app (iOS 13+); a scene-less window stays invisible even
+        // with isHidden = false. Fall back to the legacy frame init only if no
+        // foreground scene can be found.
+        if let windowScene = UIApplication.shared.connectedScenes
+            .compactMap({ $0 as? UIWindowScene })
+            .first(where: { $0.activationState == .foregroundActive }) {
+            foregroundWindow = UIWindow(windowScene: windowScene)
+        } else {
+            foregroundWindow = UIWindow(frame: UIScreen.main.bounds)
+        }
 
         guard let foregroundWindow = foregroundWindow else { return }
 


### PR DESCRIPTION
## Summary

`MediaViewer.present()` created its window with `UIWindow(frame: UIScreen.main.bounds)` and never assigned a `windowScene`. On a scene-based app (iOS 13+), a window with no `windowScene` is never rendered — `isHidden = false` is a no-op for it — so the full-screen media viewer stayed invisible when tapping a photo.

This regressed when the consuming app (h19-iphone-v2) adopted the scene-based lifecycle; the `present()` code itself hadn't changed in years.

### Fix
- Attach the active foreground `UIWindowScene` to the window before showing it.
- Fall back to the legacy `UIWindow(frame:)` init only when no foreground scene can be resolved.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Testing
- Compiled the `H19MediaViewer` SPM target against the iOS 26.5 simulator SDK — build succeeds.
- Consumer (h19-iphone-v2) affected surfaces: Feed images, Activity details, Course Profile community photos (carousel + grid) — all route through `present()`.

## Notes for consumers
After this merges and is tagged, bump the `media-viewer` SPM pin in h19-iphone-v2 (currently `exactVersion 26.0.0`).